### PR TITLE
Support for TimeWithZone as the X

### DIFF
--- a/lib/lttb/process.rb
+++ b/lib/lttb/process.rb
@@ -131,7 +131,7 @@ module Lttb
 
     def handle_dates(data)
       data.map do |d|
-        d[0] = d[0].strftime('%Q').to_i
+        d[0] = d[0].to_datetime.strftime('%Q').to_i
         d
       end
     end


### PR DESCRIPTION
When working with `TimeWithZone`, `.strftime('%Q').to_i` returns 0 which sets all the dates to January 1st 1970, 00:00:00. Instead of pre-processing data externally, I think this should handle it without issues. 